### PR TITLE
replace wiringPi with pigpio on relay_interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Development of the PoC is currently focused on [Raspbian Buster](https://www.ras
 2. Install dependencies:
 ```
 $ sudo apt-get update
-$ sudo apt-get install git python3-distutils libfastjson-dev libcurl4-gnutls-dev libsqlite3-dev
+$ sudo apt-get install git python3-distutils libfastjson-dev libcurl4-gnutls-dev libsqlite3-dev pigpio
 ```
 
 3. Download, build and install [`pigpio`](http://abyz.me.uk/rpi/pigpio/):

--- a/embedded/Makefile
+++ b/embedded/Makefile
@@ -78,7 +78,7 @@ FASTJSON = $(EXTERN)libfastjson/
 CURL_LDFLAGS = -lcurl
 SQLITE_LDFLAGS = -lsqlite3
 
-LDFLAGS = -Wl,-rpath-link,$(SYSROOT)/lib/arm-linux-gnueabihf,-rpath-link,$(SYSROOT)/usr/lib/arm-linux-gnueabihf --sysroot=$(SYSROOT) -L$(SYSROOT)/lib -L$(SYSROOT)/usr/lib -L$(SYSROOT)/usr/lib/arm-linux-gnueabihf -B$(SYSROOT)/usr/lib/arm-linux-gnueabihf -dynamic -lpthread -lwiringPi -lwiringPiDev
+LDFLAGS = -Wl,-rpath-link,$(SYSROOT)/lib/arm-linux-gnueabihf,-rpath-link,$(SYSROOT)/usr/lib/arm-linux-gnueabihf --sysroot=$(SYSROOT) -L$(SYSROOT)/lib -L$(SYSROOT)/usr/lib -L$(SYSROOT)/usr/lib/arm-linux-gnueabihf -B$(SYSROOT)/usr/lib/arm-linux-gnueabihf -dynamic -lpthread -lpigpio
 
 SRCS = \
     $(INCLUDE)Dlog.c \

--- a/embedded/modules/resolver/relay_interface.h
+++ b/embedded/modules/resolver/relay_interface.h
@@ -34,10 +34,10 @@
 #ifndef __RELAY_INTERFACE_H__
 #define __RELAY_INTERFACE_H__
 
-void RelayInterface_init();
-void RelayInterface_on(int idx);
-void RelayInterface_off(int idx);
-void RelayInterface_toggle(int idx);
-void RelayInterface_pulse(int idx);
+int RelayInterface_init();
+int RelayInterface_on(int idx);
+int RelayInterface_off(int idx);
+int RelayInterface_toggle(int idx);
+int RelayInterface_pulse(int idx);
 
 #endif


### PR DESCRIPTION
solves https://github.com/iotaledger/access/issues/23

Since @djordjeglbvc created a new plugin approach with `relay_interface.c`, the commits I had previously done on `rpi-cross` don't make much sense anymore.
So I created a new branch called `gpio`.

I successfully replaced wiringPi with pigpio on `relay_interface.c`.
Successfully tested with `on`, `off`, `toggle` and `pulse` commands with PiRelay shield.


