### PR TITLE
Added code formatter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ $ make
 
 ```
 
+## Contributing  
+
+Pull Requests are welcomed.  
+This project uses clang-format to format C/C++ code. Before you make any changes please install the format script via running `./git_hooks/pre_commit_install.sh`.  
+
 ## XAIN FROST
 IOTA Access is based on [XAIN](https://www.xain.io/)'s **FROST** project, which is the byproduct of [Leif-Nissen Lundbeak](https://www.researchgate.net/profile/Leif_Nissen_Lundbaek)'s 2019 PhD Thesis at Imperial College London.
 

--- a/git_hooks/format_check
+++ b/git_hooks/format_check
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+repo_root=$(git rev-parse --show-toplevel)
+status=0
+for file in $(git diff --staged --name-only | grep -E "\.(c|cc|cpp|h|hh|hpp)\$")
+do
+  filepath="${repo_root}/${file}"
+  output=$(diff <(cat ${filepath}) <(clang-format -style=file -fallback-style=none ${filepath}))
+  if [ $? -ne 0 ]
+  then
+    echo -e "\nFile \""$file"\" is not compliant with the coding style"
+    echo "$output"
+    status=1
+  fi
+done
+
+if [ $status -ne 0 ]; then
+    echo "Run ./git_hooks/formatter to fix it"
+fi
+
+exit $status

--- a/git_hooks/formatter
+++ b/git_hooks/formatter
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+for file in $(find $(git rev-parse --show-toplevel) | grep -E "\.(c|cc|cpp|h|hh|hpp|m|mm)\$")
+do
+  clang-format -style=file -fallback-style=none -i $file
+done
+

--- a/git_hooks/pre_commit_install.sh
+++ b/git_hooks/pre_commit_install.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Install code-style checker into pre-commit hook
+repo_root=$(git rev-parse --show-toplevel)
+git_hooks="${repo_root}/.git/hooks"
+hook_pre_commit="${repo_root}/.git/hooks/pre-commit"
+script_file="${repo_root}/git_hooks/format_check"
+
+if [ -f ${hook_pre_commit} ]; then
+    echo "pre-commit hook exists."
+    exit 1
+else
+    ln -s "${script_file}"  "${hook_pre_commit}" 
+    echo "done"
+fi
+
+exit 0


### PR DESCRIPTION
Apply clang-format to git hook for automatically checking code style before commit. Unformatted changes are unable to commit to the local repository once it's installed.

```
$ git commit
File "access/pdp/pdp.c" is not compliant with the coding style    
85c85,89                                              
<     } else if (memcmp("not", operation, size) == 0) { ret = NOT; } else if (memcmp("leq", operation, size) == 0) { ret = LEQ; } else if (memcmp("geq", operation, size) ==
0) {                                                  
---                                                     
>     } else if (memcmp("not", operation, size) == 0) {
>       ret = NOT;
>     } else if (memcmp("leq", operation, size) == 0) {
>       ret = LEQ;
>     } else if (memcmp("geq", operation, size) == 0) {
Run ./git_hooks/formatter to fix it
$ 
```